### PR TITLE
Account for \\ within kdlStrings

### DIFF
--- a/syntax/kdl.vim
+++ b/syntax/kdl.vim
@@ -25,7 +25,7 @@ syn match kdlNumber '\d[[:digit:]]*[eE][\-+]\=\d\+' contained display
 syn match kdlNumber '[-+]\=\d[[:digit:]]*\.\d*[eE][\-+]\=\d\+' contained display
 syn match kdlNumber '\d[[:digit:]]*\.\d*[eE][\-+]\=\d\+' contained display
 
-syn region kdlString start='"' end='"' skip='\\"' display
+syn region kdlString start='"' end='"' skip='\\\\\|\\"' display
  
 syn region kdlChildren start="{" end="}" contains=kdlString,kdlNumber,kdlNode,kdlBool,kdlComment
 


### PR DESCRIPTION
Hi, thank you for your plugin.

I noticed a syntax highlighting bug in my Zellij config.
![image](https://user-images.githubusercontent.com/51383304/215000038-b1b503ab-f4c6-4512-b1ed-4beb72c71714.png)

After adding `\\` to the `skip` list for `kdlString` (syntax ends up being `\\\\` then `\|` to OR the two cases), it seems fixed:
![image](https://user-images.githubusercontent.com/51383304/215000319-995b08d3-e41b-4ed7-8e24-2c2bf06e0cee.png)

I took inspiration from the `cString` syn definition in [vim's syntax/c.vim](https://github.com/vim/vim/blob/master/runtime/syntax/c.vim).

I did not test many other cases, admittedly.
