### PR TITLE
Improve the regular expression for matching identifiers

### DIFF
--- a/syntax/kdl.vim
+++ b/syntax/kdl.vim
@@ -3,7 +3,7 @@
 " Maintainer: Aram Drevekenin
 " Latest Revision: 29 September 2022
 "
-syn match kdlNode '\v(\w|-|\=)' display
+syn match kdlNode "\%([^-+.(){}\[\]/\"#;=[:digit:][:space:]]\|[-+.][^(){}\[\]/\"#;=[:space:][:digit:]]\)\%([^(){}\[\]/\"#;=[:space:]]\)*" display
 syn match kdlBool '\v(true|false)' display
 
 syn keyword kdlTodo contained TODO FIXME XXX NOTE


### PR DESCRIPTION
This PR updates the `kdlNode` definition to match more closely with the [spec](https://kdl.dev/spec/#section-3.10)

I think this technically works towards #2, but I haven't looked too closely at the changes introduced in KDL 2.0.